### PR TITLE
Fix Frends.Tasks.Attributes reference to a working version (1.2.1)

### DIFF
--- a/Frends.Web/Frends.Web.csproj
+++ b/Frends.Web/Frends.Web.csproj
@@ -33,8 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Frends.Tasks.Attributes, Version=1.2.0.0, Culture=neutral, PublicKeyToken=258fd606323928fc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Frends.Tasks.Attributes.1.2.0\lib\net40\Frends.Tasks.Attributes.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Frends.Tasks.Attributes.1.2.1\lib\net40\Frends.Tasks.Attributes.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/Frends.Web/packages.config
+++ b/Frends.Web/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Frends.Tasks.Attributes" version="1.2.0" targetFramework="net452" />
+  <package id="Frends.Tasks.Attributes" version="1.2.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net452" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -113,7 +113,6 @@ This project is licensed under the MIT License - see the LICENSE file for detail
 
 Building
 ========
-Ensure that you have `https://www.myget.org/F/frends/api/v2` added to your nuget feeds
 
 Clone a copy of the repo
 

--- a/nuspec/Frends.Web.nuspec
+++ b/nuspec/Frends.Web.nuspec
@@ -11,7 +11,6 @@
     <summary />
     <dependencies>
       <dependency id="Newtonsoft.Json" version="6.0.8" />
-	    <dependency id="Frends.Tasks.Attributes" version="1.2.0" />
     </dependencies>
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System" />
@@ -19,7 +18,7 @@
     </frameworkAssemblies>
   </metadata>
   <files>
-	<file src="Frends.Web\bin\Release\Frends.Web.dll" target="lib\net452\Frends.Web.dll" />	
+	<file src="Frends.Web\bin\Release\Frends.Web.dll" target="lib\net452\Frends.Web.dll" />
     <file src="Frends.Web\bin\Release\Frends.Web.XML" target="Frends.Web.XML"/>
     <file src="Frends.Web\FrendsTaskMetadata.json" target="FrendsTaskMetadata.json"/>
   </files>


### PR DESCRIPTION
Version 1.2.0 cannot be used as it has the wrong assembly version, so compilation will fail.