### PR TITLE
Setting encoding with charset Content-Type parameter

### DIFF
--- a/Frends.Web.Tests/UnitTest.cs
+++ b/Frends.Web.Tests/UnitTest.cs
@@ -260,5 +260,56 @@ namespace Frends.Web.Tests
             var actualFileBytes = File.ReadAllBytes(testFilePath);
             Assert.That(result.BodyBytes, Is.EqualTo(actualFileBytes));
         }
+
+        [Test]
+        public async Task RequestShouldSetEncodingWithContentTypeCharsetIgnoringCase()
+        {
+            var codePageName = "iso-8859-1";
+            var requestMessage = "åäö!";
+            var utf8ByteArray = Encoding.UTF8.GetBytes(requestMessage);
+            var expectedContentType = $"text/plain; charset={codePageName}";
+
+            _stubHttp.Stub(x => x.Post("/endpoint"))
+                .AsContentType($"text/plain; charset={codePageName}")
+                .Return("foo åäö")
+                .OK();
+
+            var contentType = new Header { Name = "cONTENT-tYpE", Value = expectedContentType };
+            var input = new Input { Method = Method.Post, Url = "http://localhost:9191/endpoint", Headers = new Header[1] { contentType }, Message = requestMessage };
+            var options = new Options { ConnectionTimeoutSeconds = 60 };
+            var result = (HttpResponse)await Web.HttpRequest(input, options, CancellationToken.None);
+            var request = _stubHttp.AssertWasCalled(called => called.Post("/endpoint")).LastRequest();
+            var requestHead = request.RequestHead;
+            var requestBodyByteArray = Encoding.GetEncoding(codePageName).GetBytes(request.Body);
+            var requestContentType = requestHead.Headers["cONTENT-tYpE"];
+
+            //Casing should not affect setting header.
+            Assert.That(requestContentType, Is.EqualTo(expectedContentType));
+            //HttpMock does not handle other encodings well, so we expect the array to be be malformed.
+            Assert.That(requestBodyByteArray, Is.Not.EqualTo(utf8ByteArray));
+        }
+        
+        [Test]
+        public async Task RequestShouldHaveUTF8BodyContentWithMalformedContentType()
+        {
+            var message = "åäö";
+            var utf8ByteArray = Encoding.UTF8.GetBytes(message);
+            var expectedContentType = "malformed";
+
+            _stubHttp.Stub(x => x.Post("/endpoint"))
+                .AsContentType($"text/plain; charset=UTF-8")
+                .Return("foo åäö")
+                .OK();
+
+            var contentType = new Header { Name = "content-type", Value = expectedContentType };
+            var input = new Input { Method = Method.Post, Url = "http://localhost:9191/endpoint", Headers = new Header[1] { contentType }, Message = message };
+            var options = new Options { ConnectionTimeoutSeconds = 60 };
+            var result = (HttpResponse)await Web.HttpRequest(input, options, CancellationToken.None);
+            var requestBody = _stubHttp.AssertWasCalled(called => called.Post("/endpoint")).LastRequest().Body;
+            var requestBodyByteArray = Encoding.UTF8.GetBytes(requestBody);
+
+            Assert.That(requestBodyByteArray, Is.EqualTo(utf8ByteArray));
+        }
+        
     }
 }

--- a/Frends.Web.Tests/packages.config
+++ b/Frends.Web.Tests/packages.config
@@ -5,4 +5,5 @@
   <package id="log4net" version="2.0.5" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net452" />
   <package id="NUnit" version="3.6.0" targetFramework="net452" />
+  <package id="NUnit3TestAdapter" version="3.6.0" targetFramework="net452" />
 </packages>

--- a/Frends.Web/Web.cs
+++ b/Frends.Web/Web.cs
@@ -297,7 +297,7 @@ namespace Frends.Web
                 contentTypeIsSetAndValid = MediaTypeWithQualityHeaderValue.TryParse(contentTypeValue, out validContentType);
 
             using (HttpContent content = contentTypeIsSetAndValid ?
-                new StringContent(input.Message ?? "", Encoding.GetEncoding(validContentType.CharSet)) :
+                new StringContent(input.Message ?? "", Encoding.GetEncoding(validContentType.CharSet ?? Encoding.UTF8.WebName)) :
                 new StringContent(input.Message ?? ""))
             {
                 //Clear default headers

--- a/Frends.Web/Web.cs
+++ b/Frends.Web/Web.cs
@@ -287,11 +287,22 @@ namespace Frends.Web
             httpClient.DefaultRequestHeaders.ExpectContinue = false;
             httpClient.Timeout = TimeSpan.FromSeconds(Convert.ToDouble(options.ConnectionTimeoutSeconds));
 
-            using (HttpContent content = new StringContent(input.Message ?? ""))
+            //Ignore case for headers and key comparison
+            var headerDict = input.Headers.ToDictionary(key => key.Name, value => value.Value, StringComparer.InvariantCultureIgnoreCase);
+
+            //Check if Content-Type exists and is set and valid
+            var contentTypeIsSetAndValid = false;
+            MediaTypeWithQualityHeaderValue validContentType = null;
+            if (headerDict.TryGetValue("content-type", out string contentTypeValue))
+                contentTypeIsSetAndValid = MediaTypeWithQualityHeaderValue.TryParse(contentTypeValue, out validContentType);
+
+            using (HttpContent content = contentTypeIsSetAndValid ?
+                new StringContent(input.Message ?? "", Encoding.GetEncoding(validContentType.CharSet)) :
+                new StringContent(input.Message ?? ""))
             {
                 //Clear default headers
                 content.Headers.Clear();
-                foreach (var header in input.Headers.ToDictionary(key => key.Name, value => value.Value))
+                foreach (var header in headerDict)
                 {
                     var requestHeaderAddedSuccessfully = httpClient.DefaultRequestHeaders.TryAddWithoutValidation(header.Key, header.Value);
                     if (!requestHeaderAddedSuccessfully)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Input:
 | Method            | Enum(Get, Post, Put, Patch, Delete)    | Http method of request.  |  `Post`  |
 | Url               | string                                 | The URL with protocol and path to call.  | `https://foo.example.org/path/to` `https://foo.example.org/path/to?Id=14` |
 | Message           | string                             | The message to be sent with the request. Not used for Get requests     | `{"Name" : "Adam", "Age":42}` |
-| Headers           | Array{Name: string, Value: string} | List of HTTP headers to be added to the request.     | `Name = Content-Type, Value = application/json` |
+| Headers           | Array{Name: string, Value: string} | List of HTTP headers to be added to the request. Setting charset parameter encodes message.    | `Name = Content-Type, Value = application/json` |
 
 Options:
 

--- a/nuspec/Frends.Web.nuspec
+++ b/nuspec/Frends.Web.nuspec
@@ -18,8 +18,8 @@
     </frameworkAssemblies>
   </metadata>
   <files>
-	  <file src="..\Frends.Web\bin\Release\Frends.Web.dll" target="lib\net452\Frends.Web.dll" />
-    <file src="..\Frends.Web\bin\Release\Frends.Web.XML" target="Frends.Web.XML"/>
-    <file src="..\Frends.Web\FrendsTaskMetadata.json" target="FrendsTaskMetadata.json"/>
+	  <file src="Frends.Web\bin\Release\Frends.Web.dll" target="lib\net452\Frends.Web.dll" />
+    <file src="Frends.Web\bin\Release\Frends.Web.XML" target="Frends.Web.XML"/>
+    <file src="Frends.Web\FrendsTaskMetadata.json" target="FrendsTaskMetadata.json"/>
   </files>
 </package>

--- a/nuspec/Frends.Web.nuspec
+++ b/nuspec/Frends.Web.nuspec
@@ -18,8 +18,8 @@
     </frameworkAssemblies>
   </metadata>
   <files>
-	<file src="Frends.Web\bin\Release\Frends.Web.dll" target="lib\net452\Frends.Web.dll" />
-    <file src="Frends.Web\bin\Release\Frends.Web.XML" target="Frends.Web.XML"/>
-    <file src="Frends.Web\FrendsTaskMetadata.json" target="FrendsTaskMetadata.json"/>
+	  <file src="..\Frends.Web\bin\Release\Frends.Web.dll" target="lib\net452\Frends.Web.dll" />
+    <file src="..\Frends.Web\bin\Release\Frends.Web.XML" target="Frends.Web.XML"/>
+    <file src="..\Frends.Web\FrendsTaskMetadata.json" target="FrendsTaskMetadata.json"/>
   </files>
 </package>


### PR DESCRIPTION
Ignores case of "contenT-TypE".

Can send malformed content-types, but results in UTF-8 encoded message.

If Content-Type form is valid but codepage cannot be found, results in error _"System.InvalidOperationException : The character set provided in ContentType is invalid. Cannot read content as string using an invalid character set."_

HttpMock couldn't handle requests with other than UTF-8 encoding. Can't properly check bytearrays.

Does not force Content-Type, it let's StringContent decide it. If content-type is malformed, it uses the malformed content-type but does not try to encode message, as per current implementation with TryAddWithoutValidation() and uses UTF-8 encoding instead.