### PR TITLE
Add new task to send binary data in HTTP content (issue #20)

### DIFF
--- a/Frends.Web.Tests/Frends.Web.Tests.csproj
+++ b/Frends.Web.Tests/Frends.Web.Tests.csproj
@@ -35,9 +35,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="HttpMock, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\HttpMock.1.3.1\lib\net45\HttpMock.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="HttpMock, Version=2.0.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\HttpMock.2.3.0\lib\net45\HttpMock.dll</HintPath>
+    </Reference>
+    <Reference Include="HttpMock.Verify.NUnit, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\HttpMock.Verify.NUnit.1.1.0\lib\net45\HttpMock.Verify.NUnit.dll</HintPath>
     </Reference>
     <Reference Include="Kayak, Version=0.7.2.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Kayak.0.7.2\lib\Kayak.dll</HintPath>
@@ -52,9 +54,8 @@
       <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.6.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.3.6.0\lib\net45\nunit.framework.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="nunit.framework, Version=3.10.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.10.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>

--- a/Frends.Web.Tests/app.config
+++ b/Frends.Web.Tests/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="nunit.framework" publicKeyToken="2638cd05610744eb" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.6.0.0" newVersion="3.6.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-3.10.1.0" newVersion="3.10.1.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Frends.Web.Tests/packages.config
+++ b/Frends.Web.Tests/packages.config
@@ -1,9 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="HttpMock" version="1.3.1" targetFramework="net452" />
+  <package id="HttpMock" version="2.3.0" targetFramework="net452" />
+  <package id="HttpMock.Verify.NUnit" version="1.1.0" targetFramework="net452" />
   <package id="Kayak" version="0.7.2" targetFramework="net452" />
   <package id="log4net" version="2.0.5" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net452" />
-  <package id="NUnit" version="3.6.0" targetFramework="net452" />
+  <package id="NUnit" version="3.10.1" targetFramework="net452" />
   <package id="NUnit3TestAdapter" version="3.6.0" targetFramework="net452" />
 </packages>

--- a/Frends.Web/Frends.Web.csproj
+++ b/Frends.Web/Frends.Web.csproj
@@ -54,7 +54,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="FrendsTaskMetadata.json" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Frends.Web/FrendsTaskMetadata.json
+++ b/Frends.Web/FrendsTaskMetadata.json
@@ -7,6 +7,9 @@
       "TaskMethod": "Frends.Web.Web.HttpRequestBytes"
     },
     {
+      "TaskMethod": "Frends.Web.Web.HttpSendBytes"
+    },
+    {
       "TaskMethod": "Frends.Web.Web.RestRequest"
     }
   ]

--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ If the response is not valid JSON, the task will throw an JsonReaderException wi
 
 Input:
 
-| Property          | Type                               | Description                                             | Example                                   |
-|-------------------|----------------------------------------|---------------------------------------------------------|-------------------------------------------|
-| Method            | Enum(Get, Post, Put, Patch, Delete)    | Http method of request.  |  `Post`  |
-| Url               | string                                 | The URL with protocol and path to call.  | `https://foo.example.org/path/to` `https://foo.example.org/path/to?Id=14` |
-| Message           | string                             | The message to be sent with the request. Not used for Get requests     | `{"Name" : "Adam", "Age":42}` |
-| Headers           | Array{Name: string, Value: string} | List of HTTP headers to be added to the request. Setting charset parameter encodes message.    | `Name = Content-Type, Value = application/json` |
+| Property          | Type													      | Description                                             | Example                                   |
+|-------------------|-------------------------------------------------------------|---------------------------------------------------------|-------------------------------------------|
+| Method            | Enum(GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS, CONNECT) | Http method of request.  |  `POST`  |
+| Url               | string													  | The URL with protocol and path to call.  | `https://foo.example.org/path/to` `https://foo.example.org/path/to?Id=14` |
+| Message           | string													  | The message to be sent with the request. Not used for Get requests     | `{"Name" : "Adam", "Age":42}` |
+| Headers           | Array{Name: string, Value: string}						  | List of HTTP headers to be added to the request. Setting charset parameter encodes message.    | `Name = Content-Type, Value = application/json` |
 
 Options:
 
@@ -62,12 +62,12 @@ HttpRequest is a generic HTTP request task. It accepts any type of string respon
 
 Input:
 
-| Property          | Type                               | Description                                                                | Example                                   |
-|-------------------|----------------------------------------|------------------------------------------------------------------------|-------------------------------------------|
-| Message           | string                                 | The message to be sent with the request. Not used for Get requests     | `{"Name" : "Adam", "Age":42}`             |
-| Method            | Enum(Get, Post, Put, Patch, Delete)    | Http method of request.                                                | `Post`                                    |
-| Url               | string                                 | The URL with protocol and path to call                                 | `https://foo.example.org/path/to?Id=14`   |
-| Headers           | Array{Name: string, Value: string}     | List of HTTP headers to be added to the request.                       | `Name = Content-Type, Value = application/json` |
+| Property          | Type													      | Description                                                                | Example                                   |
+|-------------------|-------------------------------------------------------------|------------------------------------------------------------------------|-------------------------------------------|
+| Message           | string													  | The message to be sent with the request. Not used for Get requests     | `{"Name" : "Adam", "Age":42}`             |
+| Method            | Enum(GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS, CONNECT) | Http method of request.                                                | `POST`                                    |
+| Url               | string                                                      | The URL with protocol and path to call                                 | `https://foo.example.org/path/to?Id=14`   |
+| Headers           | Array{Name: string, Value: string}						  | List of HTTP headers to be added to the request.                       | `Name = Content-Type, Value = application/json` |
 
 Options:
 
@@ -105,6 +105,20 @@ Result:
 | ContentType		| System.Net.Http.Headers.MediaTypeHeaderValue | The parsed media type header from the response, so you can e.g. get the media type string by `#result.ContentType.MediaType`  |
 | Headers           | Dictionary<string,string>                    | Response headers, with multiple values for the same header combined by semicolons (;)                                         |
 | StatusCode        | int                                          | Response status code                                                                                                          | 
+
+## HttpSendBytes
+HttpSendBytes can be used to send binary data as the content. This can be useful for e.g. pushing file data or gzip compressed content.
+
+Input:
+
+| Property          | Type                                   | Description																	| Example                                   |
+|-------------------|----------------------------------------|------------------------------------------------------------------------------|-------------------------------------------|
+| ContentBytes      | byte[]                                 | The message to be sent with the request. Not used for Get requests			| `#result[Read file]`                      |
+| Method            | Enum(POST, PUT, PATCH)                 | Http method of request. Only those methods that can have contetn are allowed | `POST`                                    |
+| Url               | string                                 | The URL with protocol and path to call                                       | `https://foo.example.org/path/to?Id=14`   |
+| Headers           | Array{Name: string, Value: string}     | List of HTTP headers to be added to the request.                             | `Name = Content-Encoding, Value = gzip`   |
+
+The Options and task result are the same as with the [HttpRequest](#httprequest) task.
 
 License
 =======

--- a/nuspec/Frends.Web.nuspec
+++ b/nuspec/Frends.Web.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
   <metadata>
     <id>Frends.Web</id>
-    <version>1.0.0.0</version>
+    <version>1.1.0</version>
     <title>FRENDS Web tasks</title>
     <authors>HiQ Finland</authors>
     <owners />


### PR DESCRIPTION
Also fixed issue #19: if response content is empty, updating the response content headers is no longer attempted