### PR TITLE
issue #10: The tasks now cache the HTTP clients per App domain and Option combination

### DIFF
--- a/Frends.Web.Tests/UnitTest.cs
+++ b/Frends.Web.Tests/UnitTest.cs
@@ -121,8 +121,21 @@ namespace Frends.Web.Tests
                .Return(expectedReturn)
                .OK();
 
-            var input = new Input { Method = Method.GET, Url = "http://localhost:9191/endpoint", Headers = new Header[0], Message = "" };
-            var options = new Options { ConnectionTimeoutSeconds = 60, ThrowExceptionOnErrorResponse = true, Authentication = Authentication.Basic, Username = "Foo", Password = "Bar" };
+            var input = new Input
+            {
+                Method = Method.GET,
+                Url = "http://localhost:9191/endpoint",
+                Headers = new Header[0],
+                Message = ""
+            };
+            var options = new Options
+            {
+                ConnectionTimeoutSeconds = 60,
+                ThrowExceptionOnErrorResponse = true,
+                Authentication = Authentication.Basic,
+                Username = "Foo",
+                Password = "Bar"
+            };
             await Web.RestRequest(input, options, CancellationToken.None);
 
             var requestHeaders = _stubHttp.AssertWasCalled(called => called.Get("/endpoint")).LastRequest().RequestHead;
@@ -141,8 +154,19 @@ namespace Frends.Web.Tests
                .Return(expectedReturn)
                .OK();
 
-            var input = new Input { Method = Method.GET, Url = "http://localhost:9191/endpoint", Headers = new Header[0], Message = "" };
-            var options = new Options { ConnectionTimeoutSeconds = 60, Authentication = Authentication.OAuth, Token = "fooToken" };
+            var input = new Input
+            {
+                Method = Method.GET,
+                Url = "http://localhost:9191/endpoint",
+                Headers = new Header[0],
+                Message = ""
+            };
+            var options = new Options
+            {
+                ConnectionTimeoutSeconds = 60,
+                Authentication = Authentication.OAuth,
+                Token = "fooToken"
+            };
             await Web.RestRequest(input, options, CancellationToken.None);
 
             var requestHeaders = _stubHttp.AssertWasCalled(called => called.Get("/endpoint")).LastRequest().RequestHead;
@@ -160,11 +184,24 @@ namespace Frends.Web.Tests
                 .Return(expectedReturn)
                 .OK();
             const string thumbprint = "ABCD";
-            var input = new Input { Method = Method.GET, Url = "http://localhost:9191/endpoint", Headers = new Header[0], Message = "" };
-            var options = new Options { ConnectionTimeoutSeconds = 60, ThrowExceptionOnErrorResponse = true, Authentication = Authentication.ClientCertificate, CertificateThumbprint = thumbprint };
+            var input = new Input
+            {
+                Method = Method.GET,
+                Url = "http://localhost:9191/endpoint",
+                Headers = new Header[0],
+                Message = ""
+            };
+            var options = new Options
+            {
+                ConnectionTimeoutSeconds = 60,
+                ThrowExceptionOnErrorResponse = true,
+                Authentication = Authentication.ClientCertificate,
+                CertificateThumbprint = thumbprint
+            };
 
 
-            var ex = Assert.ThrowsAsync<FileNotFoundException>(async () => await Web.RestRequest(input, options, CancellationToken.None));
+            var ex = Assert.ThrowsAsync<FileNotFoundException>(async () =>
+                await Web.RestRequest(input, options, CancellationToken.None));
 
             Assert.That(ex.Message, Does.Contain($"Certificate with thumbprint: '{thumbprint}' not"));
         }

--- a/Frends.Web/Web.cs
+++ b/Frends.Web/Web.cs
@@ -226,7 +226,7 @@ namespace Frends.Web
 
     public class Web
     {
-        private static ConcurrentDictionary<int, HttpClient> ClientCache = new ConcurrentDictionary<int, HttpClient>();
+        private static ConcurrentDictionary<Options, HttpClient> ClientCache = new ConcurrentDictionary<Options, HttpClient>();
 
         /// <summary>
         /// For a more detailed documentation see: https://github.com/FrendsPlatform/Frends.Web#RestRequest
@@ -274,16 +274,14 @@ namespace Frends.Web
 
         private static HttpClient GetHttpClientForOptions(Options options)
         {
-            // TODO: Is getHashCode() good enough, or should we use a real hash func, like SHA-1?
-            var optionHash = options.GetHashCode();
-            return ClientCache.GetOrAdd(optionHash, (key) =>
+            return ClientCache.GetOrAdd(options, (opts) =>
             {
                 // might get called more than once if e.g. many process instances execute at once,
                 // but that should not matter much, as only one client will get cached
                 var handler = new WebRequestHandler();
-                handler.SetHandlerSettingsBasedOnOptions(options);
+                handler.SetHandlerSettingsBasedOnOptions(opts);
                 var httpClient = new HttpClient(handler);
-                httpClient.SetDefaultRequestHeadersBasedOnOptions(options);
+                httpClient.SetDefaultRequestHeadersBasedOnOptions(opts);
 
                 return httpClient;
             });
@@ -560,7 +558,7 @@ namespace Frends.Web
                 }
             }
 
-            //Do not automtically set expect 100-continue response header
+            //Do not automatically set expect 100-continue response header
             httpClient.DefaultRequestHeaders.ExpectContinue = false;
             httpClient.DefaultRequestHeaders.TryAddWithoutValidation("content-type", "application/json");
             httpClient.Timeout = TimeSpan.FromSeconds(Convert.ToDouble(options.ConnectionTimeoutSeconds));


### PR DESCRIPTION
Fix for issue #10 

The tasks now cache the HTTP clients per App domain (i.e. FRENDS process) and each Option combination used.

If you do two calls with e.g. different authentication methods, you will get to clients cached for that process.

The clients will be released only when the app domains themselves are unloaded, but that should be fine as the actual HTTP connections get released from the pool by the default timeouts.