### PR TITLE
Add AutomaticCookieHandling option

### DIFF
--- a/Frends.Web/Web.cs
+++ b/Frends.Web/Web.cs
@@ -158,6 +158,12 @@ namespace Frends.Web
         /// </summary>
         public bool ThrowExceptionOnErrorResponse { get; set; }
 
+        /// <summary>
+        /// If set to false, cookies must be handled manually. Defaults to true.
+        /// </summary>
+        [DefaultValue(true)]
+        public bool AutomaticCookieHandling { get; set; } = true;
+
         public bool Equals(Options other)
         {
             if (ReferenceEquals(null, other)) return false;
@@ -171,7 +177,8 @@ namespace Frends.Web
                    FollowRedirects == other.FollowRedirects &&
                    AllowInvalidCertificate == other.AllowInvalidCertificate &&
                    AllowInvalidResponseContentTypeCharSet == other.AllowInvalidResponseContentTypeCharSet &&
-                   ThrowExceptionOnErrorResponse == other.ThrowExceptionOnErrorResponse;
+                   ThrowExceptionOnErrorResponse == other.ThrowExceptionOnErrorResponse &&
+                   AutomaticCookieHandling == other.AutomaticCookieHandling;
         }
 
         public override bool Equals(object obj)
@@ -196,6 +203,7 @@ namespace Frends.Web
                 hashCode = (hashCode * 397) ^ AllowInvalidCertificate.GetHashCode();
                 hashCode = (hashCode * 397) ^ AllowInvalidResponseContentTypeCharSet.GetHashCode();
                 hashCode = (hashCode * 397) ^ ThrowExceptionOnErrorResponse.GetHashCode();
+                hashCode = (hashCode * 397) ^ AutomaticCookieHandling.GetHashCode();
                 return hashCode;
             }
         }
@@ -611,6 +619,7 @@ namespace Frends.Web
             }
 
             handler.AllowAutoRedirect = options.FollowRedirects;
+            handler.UseCookies = options.AutomaticCookieHandling;
 
             if (options.AllowInvalidCertificate)
             {

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Options:
 | Password                         | string                             | This field is available for Basic- and Windows Authentication.  |
 | Token                            | string                             | Token to be used in an OAuth request. The token will be added as a Authentication header. `Authorization Bearer '{Token}'` |
 | CertificateThumbprint            | string                             | This field is used with Client Certificate Authentication. The certificate needs to be found in Cert\CurrentUser\My store on the agent running the process |
+| AutomaticCookieHandling          | bool                               | If set to false, cookies must be handled manually through Cookie -header. Defaults to true. |
 
 Result:
 
@@ -86,6 +87,7 @@ Options:
 | Password                         | string                             | This field is available for Basic- and Windows Authentication.  |
 | Token                            | string                             | Token to be used in an OAuth request. The token will be added as a Authentication header. `Authorization Bearer '{Token}'` |
 | CertificateThumbprint            | string                             | This field is used with Client Certificate Authentication. The certificate needs to be found in Cert\CurrentUser\My store on the agent running the process |
+| AutomaticCookieHandling          | bool                               | If set to false, cookies must be handled manually through Cookie -header. Defaults to true. |
 
 Result:
 


### PR DESCRIPTION
Added Options::AutomaticCookieHandling -property to be able to control how the cookies are handled. By default the HttpClientHandler.UseCookies -property is true and therefore the cookies are handled automatically with the CookieContainer and the Cookie -header is ignored by the HttpClientHandler. Setting this to false allows setting the Cookie -header manually from the FRENDS process.