### PR TITLE
Address memory leak when using 'Token' authentication (#41)

### DIFF
--- a/Frends.Web.Tests/UnitTest.cs
+++ b/Frends.Web.Tests/UnitTest.cs
@@ -202,6 +202,33 @@ namespace Frends.Web.Tests
             _mockHttpMessageHandler.VerifyNoOutstandingExpectation();
         }
 
+        [Theory]
+        [MemberData(nameof(TestDataSource.TestCases), MemberType = typeof(TestDataSource))]
+        public async Task AuthorizationHeaderShouldOverrideOption(
+            Func<Input, Options, CancellationToken, Task<object>> requestFunc)
+        {
+            const string expectedReturn = @"'FooBar'";
+
+            var input = new Input
+            {
+                Method = Method.GET,
+                Url = "http://localhost:9191/endpoint",
+                Headers = new[] { new Header() { Name = "Authorization", Value = "Basic fooToken" } },
+                Message = ""
+            };
+            var options = new Options
+            {
+                ConnectionTimeoutSeconds = 60,
+                Authentication = Authentication.OAuth,
+                Token = "barToken"
+            };
+
+            _mockHttpMessageHandler.Expect($"{BasePath}/endpoint").WithHeaders("Authorization", "Basic fooToken")
+                .Respond("application/json", expectedReturn);
+            await requestFunc(input, options, CancellationToken.None);
+            _mockHttpMessageHandler.VerifyNoOutstandingExpectation();
+        }
+
         [Fact]
         public async Task RequestShouldAddClientCertificate()
         {

--- a/Frends.Web.Tests/UnitTest.cs
+++ b/Frends.Web.Tests/UnitTest.cs
@@ -529,5 +529,36 @@ namespace Frends.Web.Tests
 
             Assert.Equal(actualFileBytes, result.BodyBytes);
         }
+
+        [Fact]
+        public async Task ShouldUseSameClientEvenIfOAuthTokenChanges()
+        {
+            var requestBytes = Encoding.UTF8.GetBytes("some request data");
+
+            var input = new ByteInput
+            {
+                Method = SendMethod.POST,
+                Url = "http://localhost:9191/endpoint",
+                Headers = new[] {
+                    new Header { Name = "Content-Type", Value = "text/plain; charset=utf-8" },
+                    new Header { Name ="Content-Length", Value = requestBytes.Length.ToString() }
+                },
+                ContentBytes = requestBytes
+            };
+            var options = new Options { ConnectionTimeoutSeconds = 60, Authentication = Authentication.OAuth };
+
+            _mockHttpMessageHandler.When(input.Url)
+                .Respond("application/octet-stream", string.Empty);
+
+            for (var i = 0; i < 2; i++)
+            {
+                options.Token = i + "";
+                var result = (HttpByteResponse)await Web.HttpSendAndReceiveBytes(input, options, CancellationToken.None);
+                Assert.Equal(0, result.BodySizeInMegaBytes);
+                Assert.Empty(result.BodyBytes);
+            }
+
+            Assert.Equal(1, Web.ClientCache.GetCount());
+        }
     }
 }

--- a/Frends.Web/Frends.Web.csproj
+++ b/Frends.Web/Frends.Web.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.Caching" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="FrendsTaskMetadata.json"  Pack="true" PackagePath="/">


### PR DESCRIPTION
Added cache for http clients and removed token from cache, as suggested in #41 